### PR TITLE
README: Fix `<leader>tldo/tldf` mapping which is reversed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ nmap <leader>tlp <Plug>(toggle-lsp-diag-update_in_insert)
 
 nmap <leader>tld  <Plug>(toggle-lsp-diag)
 nmap <leader>tldd <Plug>(toggle-lsp-diag-default)
-nmap <leader>tldo <Plug>(toggle-lsp-diag-off)
-nmap <leader>tldf <Plug>(toggle-lsp-diag-on)
+nmap <leader>tldo <Plug>(toggle-lsp-diag-on)
+nmap <leader>tldf <Plug>(toggle-lsp-diag-off)
 ```
 
 ## Commands


### PR DESCRIPTION
The README's example configuration uses `tldo` for "Off" and `tldf` for "On". This seems backwards as there's an `f` in "Off", not in "On.
```
nmap <leader>tldo <Plug>(toggle-lsp-diag-off)
nmap <leader>tldf <Plug>(toggle-lsp-diag-on)
```

This PR simply changes to map `tldo` to "On" and `tldf` to "Off".

Oops! https://github.com/WhoIsSethDaniel/toggle-lsp-diagnostics.nvim was archived literally archived 24 hours ago. Oh well, merging to my fork instead.